### PR TITLE
Fix issue where keys can stick in held state when holding down and then going into app switcher at the same time on iOS

### DIFF
--- a/cypress/e2e/game/gameplay.cy.js
+++ b/cypress/e2e/game/gameplay.cy.js
@@ -879,5 +879,38 @@ describe("gameplay", () => {
                 });
             });
         });
+
+        describe("when player holds down a key then it gets cancelled", () => {
+            it("should change the key back to its previous state", () => {
+                cy.keyboardItem("p").click();
+                cy.keyboardItem("l").click();
+                cy.keyboardItem("a").click();
+                cy.keyboardItem("z").click();
+                cy.keyboardItem("a").click();
+
+                cy.keyboardItem("enter").click();
+
+                cy.keyboardItem("p").should("have.class", "incorrect");
+                cy.keyboardItem("l").should("have.class", "within");
+                cy.keyboardItem("a").should("have.class", "correct");
+                cy.keyboardItem("z").should("have.class", "incorrect");
+
+                cy.keyboardItem("p").as("p");
+
+                cy.get("@p").should("have.class", "incorrect");
+                cy.get("@p").should("not.have.class", "pressed");
+
+                cy.get("@p").trigger("touchstart");
+
+                cy.get("@p").should("have.class", "pressed");
+                cy.get("@p").should("not.have.class", "incorrect");
+
+                cy.wait(100);
+                cy.get("@p").trigger("touchcancel");
+
+                cy.get("@p").should("have.class", "incorrect");
+                cy.get("@p").should("not.have.class", "pressed");
+            });
+        });
     });
 });

--- a/src/render.js
+++ b/src/render.js
@@ -62,6 +62,8 @@ const renderKeyboard = (parentElem, letterMap, handleKeyInput, handleHoldInput, 
                 if (Date.now() - downTime >= KEY_HOLD_TIMEOUT_MS) {
                     handleHoldInput(item);
                 }
+            };
+            const handleRelease = () => {
                 itemElem.classList.remove("pressed");
                 itemElem.classList.remove("held");
                 itemElem.classList.add(letterStatus || "standard");
@@ -74,13 +76,18 @@ const renderKeyboard = (parentElem, letterMap, handleKeyInput, handleHoldInput, 
             itemElem.addEventListener("touchend", (e) => {
                 e.preventDefault();
                 handleUp();
+                handleRelease();
                 handleKeyInput(item);
+            });
+            itemElem.addEventListener("touchcancel", (e) => {
+                handleRelease();
             });
             itemElem.addEventListener("mousedown", (e) => {
                 handleDown();
             });
             itemElem.addEventListener("mouseup", (e) => {
                 handleUp();
+                handleRelease();
             });
             const letterElem = document.createElement("div");
             letterElem.innerHTML =


### PR DESCRIPTION
This is addressed by adding a "touchcancel" event handler, which is needed to handle cases like this.