### PR TITLE
Re-randomize snow positions when window is resized (for snow theme)

### DIFF
--- a/index.css
+++ b/index.css
@@ -550,10 +550,6 @@ a {
     pointer-events: none;
 }
 
-body.landscape .embedim-snow {
-    display: none;
-}
-
 body .footer > .snow-theme-credits {
     opacity: 0;
     pointer-events: none;

--- a/vendor/snow.js
+++ b/vendor/snow.js
@@ -1,66 +1,94 @@
 /* https://embed.im/snow */
+/* with some modifications made for wordle-clone:
+- Positions are re-randomized whenever window is resized. 
+    This addresses an issue where opening and closing the Inspect pane (when docked the bottom)
+    or switching the device orientation from portrait to landscape (or vice versa) causes the 
+    snowfall to not readjust itself.
+    Originally, I was going to just remove and re-add the base element to the DOM, but I found
+    that when the page is refreshed in landscape mode and the orientation is switched back to portrait, 
+    some snowflakes are locked in place and some snowflakes end up falling at a slow rate.
+    By re-randomizing the positions as well, this issue is fixed as well.
+*/
 var embedimSnow = document.getElementById("embedim--snow");
 if (!embedimSnow) {
     function embRand(a, b) {
         return Math.floor(Math.random() * (b - a + 1)) + a;
     }
-    var embCSS =
-        ".embedim-snow{position: absolute;width: 10px;height: 10px;background: white;border-radius: 50%;margin-top:-10px}";
-    var embHTML = "";
-    for (i = 1; i < 200; i++) {
-        embHTML += '<i class="embedim-snow"></i>';
-        var rndX = embRand(0, 1000000) * 0.0001,
-            rndO = embRand(-100000, 100000) * 0.0001,
-            rndT = (embRand(3, 8) * 10).toFixed(2),
-            rndS = (embRand(0, 10000) * 0.0001).toFixed(2);
-        embCSS +=
-            ".embedim-snow:nth-child(" +
-            i +
-            "){" +
-            "opacity:" +
-            (embRand(1, 10000) * 0.0001).toFixed(2) +
-            ";" +
-            "transform:translate(" +
-            rndX.toFixed(2) +
-            "vw,-10px) scale(" +
-            rndS +
-            ");" +
-            "animation:fall-" +
-            i +
-            " " +
-            embRand(10, 30) +
-            "s -" +
-            embRand(0, 30) +
-            "s linear infinite" +
-            "}" +
-            "@keyframes fall-" +
-            i +
-            "{" +
-            rndT +
-            "%{" +
-            "transform:translate(" +
-            (rndX + rndO).toFixed(2) +
-            "vw," +
-            rndT +
-            "vh) scale(" +
-            rndS +
-            ")" +
-            "}" +
-            "to{" +
-            "transform:translate(" +
-            (rndX + rndO / 2).toFixed(2) +
-            "vw, 105vh) scale(" +
-            rndS +
-            ")" +
-            "}" +
-            "}";
+    const generateSnowflakeElements = () => {
+        let snowHTML = "";
+        let snowCSS = "";
+        for (i = 1; i < 200; i++) {
+            snowHTML += '<i class="embedim-snow"></i>';
+            var rndX = embRand(0, 1000000) * 0.0001,
+                rndO = embRand(-100000, 100000) * 0.0001,
+                rndT = (embRand(3, 8) * 10).toFixed(2),
+                rndS = (embRand(0, 10000) * 0.0001).toFixed(2);
+            snowCSS +=
+                ".embedim-snow:nth-child(" +
+                i +
+                "){" +
+                "opacity:" +
+                (embRand(1, 10000) * 0.0001).toFixed(2) +
+                ";" +
+                "transform:translate(" +
+                rndX.toFixed(2) +
+                "vw,-10px) scale(" +
+                rndS +
+                ");" +
+                "animation:fall-" +
+                i +
+                " " +
+                embRand(10, 30) +
+                "s -" +
+                embRand(0, 30) +
+                "s linear infinite" +
+                "}" +
+                "@keyframes fall-" +
+                i +
+                "{" +
+                rndT +
+                "%{" +
+                "transform:translate(" +
+                (rndX + rndO).toFixed(2) +
+                "vw," +
+                rndT +
+                "vh) scale(" +
+                rndS +
+                ")" +
+                "}" +
+                "to{" +
+                "transform:translate(" +
+                (rndX + rndO / 2).toFixed(2) +
+                "vw, 105vh) scale(" +
+                rndS +
+                ")" +
+                "}" +
+                "}";
+        }
+        return {
+            html: snowHTML,
+            css: snowCSS,
+        };
     }
+    const setSnowElementInnerHTML = () => {
+        embedimSnow.innerHTML =
+            "<style>#embedim--snow{position:fixed;left:0;top:0;bottom:0;width:100vw;height:100vh;overflow:hidden;z-index:9999999;pointer-events:none}" +
+            baseEmbCSS + snowElements.css +
+            "</style>" +
+            snowElements.html;
+    };
+    var baseEmbCSS =
+        ".embedim-snow{position: absolute;width: 10px;height: 10px;background: white;border-radius: 50%;margin-top:-10px}";
+    var snowElements = generateSnowflakeElements();
+
     embedimSnow = document.createElement("div");
     embedimSnow.id = "embedim--snow";
-    embedimSnow.innerHTML =
-        "<style>#embedim--snow{position:fixed;left:0;top:0;bottom:0;width:100vw;height:100vh;overflow:hidden;z-index:9999999;pointer-events:none}" +
-        embCSS +
-        "</style>" +
-        embHTML;
+    setSnowElementInnerHTML();
+    
     document.body.appendChild(embedimSnow);
+    
+    addEventListener("resize", (e) => {
+        snowElements = generateSnowflakeElements();
+        setSnowElementInnerHTML();
+    })
 }


### PR DESCRIPTION
Closes #37.

I have addressed the issue by re-randomizing the snowflake positions when window is resized. By resetting the HTML/CSS in this way, this ensures that the snow theme is resized properly when window is resized abruptly like when inspect pane is opened/closed or when the orientation is switched.

I've also removed the CSS property that hid the snowfall when in landscape mode, since this problem is fixed now.