### PR TITLE
Adjust z-indexes of overlay and snow elements so that snow will dim when overlay is opened

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,44 @@ wordle
 - Share functionality
 - Countdown to next day's Wordle
 
+## Development
+
+Clone this repository, then run the following:
+
+```
+npm install
+```
+
+It's also a good idea to scramble the words when working on the project, to prevent spoilers:
+
+```
+./scripts/gen_word_list.sh
+```
+
+The following will make it so that git doesn't detect that `words.txt` changed:
+
+```
+git update-index --assume-unchanged words.txt
+```
+
+At this point, you can run a local web server on the project directory, and the game should render when navigating to the port of the server from your browser.
+
+## Testing
+
+Cypress tests can be accessed by running the following:
+
+```
+npm run cypress open
+```
+
+This will launch the tests in the Cypress UI. 
+
+Alternatively, you can run the tests directly on CLI:
+
+```
+npm run cypress run
+```
+
 ## Future Additions
 
 - Hard Mode

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ It's also a good idea to scramble the words when working on the project, to prev
 ./scripts/gen_word_list.sh
 ```
 
+(Note: If you're on Windows, run the script in WSL)
+
 The following will make it so that git doesn't detect that `words.txt` changed:
 
 ```
@@ -68,6 +70,12 @@ git update-index --assume-unchanged words.txt
 At this point, you can run a local web server on the project directory, and the game should render when navigating to the port of the server from your browser.
 
 ## Testing
+
+Run the following to launch unit tests:
+
+```
+npm run test
+```
 
 Cypress tests can be accessed by running the following:
 

--- a/index.css
+++ b/index.css
@@ -338,6 +338,7 @@ button.close {
     left: 50%;
     right: 0;
     bottom: 0;
+    z-index: 101;
     transform: translate(-50%, 0);
 
     background-color: lightgrey;

--- a/index.css
+++ b/index.css
@@ -251,6 +251,7 @@ button.close {
     height: 100%;
     background-color: rgba(0, 0, 0, 0.5);
     display: none;
+    z-index: 100;
 }
 
 /* Dialog Window */
@@ -261,6 +262,7 @@ button.close {
     left: 50%;
     right: 0;
     bottom: 0;
+    z-index: 101;
     transform: translate(-50%, -50%);
 
     background-color: var(--dialog-background-color);

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
                 <div class="space"></div>
                 <div class="footer">
                     <span>
-                        &copy 2022 <a class="author-link" href="https://www.jamescote.ca/" target="_blank">James Cote</a>
+                        &copy 2022-2023 <a class="author-link" href="https://www.jamescote.ca/" target="_blank">James Cote</a>
                     </span><br/>
                     <span class="snow-theme-credits">
                         Snow effect from <a href="https://embed.im/snow/" target="_blank">embed.im</a>

--- a/src/index.js
+++ b/src/index.js
@@ -330,9 +330,13 @@ document.addEventListener("DOMContentLoaded", async () => {
         if (md && mediaQueryEvent.matches && md.mobile()) {
             document.getElementById("landscape-overlay").style.display = "block";
             document.body.classList.add(LANDSCAPE_CLASS_NAME);
+            // Have the snow element appear on top of the landscape overlay
+            // (will only be visible if the "display" attribute is set, though)
+            if (snowEmbed) snowEmbed.style.zIndex = "99999";
         } else {
             document.getElementById("landscape-overlay").style.display = "none";
             document.body.classList.remove(LANDSCAPE_CLASS_NAME);
+            if (snowEmbed) snowEmbed.style.zIndex = "";
         }
     };
 

--- a/vendor/snow.js
+++ b/vendor/snow.js
@@ -12,7 +12,12 @@
     have the snow theme enabled. After the page loads, the theme settings will either make it
     visible or invisible depending on whether snow theme is set. This will prevent the snowfall
     from appearing briefly upon page load for players who don't have snow theme enabled.
+- z-index is set so that it's underneath the overlay elements of the game
+    (which have z-index of 100 or over)
+    This will allow the snow elements to be dimmed alongside the rest of the elements
+    underneath the overlay when it appears.
 */
+const zIndex = -10;
 var embedimSnow = document.getElementById("embedim--snow");
 if (!embedimSnow) {
     function embRand(a, b) {
@@ -76,7 +81,7 @@ if (!embedimSnow) {
     }
     const setSnowElementInnerHTML = () => {
         embedimSnow.innerHTML =
-            "<style>#embedim--snow{position:fixed;left:0;top:0;bottom:0;width:100vw;height:100vh;overflow:hidden;z-index:9999999;pointer-events:none}" +
+            `<style>#embedim--snow{position:fixed;left:0;top:0;bottom:0;width:100vw;height:100vh;overflow:hidden;z-index:${zIndex};pointer-events:none}` +
             baseEmbCSS + snowElements.css +
             "</style>" +
             snowElements.html;


### PR DESCRIPTION
Snow elements will now appear beneath the game board as well, since the z-index has been adjusted to be -10, below everything else.

Also add some extra information to the README about setting up the game for development.