### PR TITLE
Allow the ability to switch to hard mode after the game is over, on both browser and CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ node_modules
 build
 
 state.json
-playedbefore.json
 preferences.json
 
 # Cypress output

--- a/cli.js
+++ b/cli.js
@@ -111,7 +111,7 @@ const runGame = async () => {
     if (mode) {
         if (!difficultyFlags.includes(mode)) {
             console.error("Not a valid difficulty (--hard|--easy)");
-        } else if (!hardMode && gameState.attempts.length > 0) {
+        } else if (!hardMode && gameState.attempts.length > 0 && !gameState.ended) {
             console.error("Cannot switch difficulty while game is in progress");
         } else {
             hardMode = mode === "--hard";
@@ -137,7 +137,8 @@ const runGame = async () => {
             answer,
             hardMode && gameState.attempts.length > 0
                 ? gameState.attempts[gameState.attempts.length - 1]
-                : null
+                : null,
+            hardMode
         );
     }
     if (isWinner) {
@@ -145,7 +146,9 @@ const runGame = async () => {
         if (answer.toLowerCase() === "y" || answer.toLowerCase() === "yes") {
             import("clipboardy").then((clipboard) => {
                 clipboard.default.writeSync(
-                    generateShareText(day, gameState.attempts, STARTING_LIVES)
+                    generateShareText(day, gameState.attempts, STARTING_LIVES, {
+                        hardMode: gameState.wonHardMode,
+                    })
                 );
                 console.log("Copied to clipboard");
             });

--- a/cypress/e2e/game/misc.cy.js
+++ b/cypress/e2e/game/misc.cy.js
@@ -55,7 +55,7 @@ describe("misc", () => {
             cy.contains("Not enough letters").should("be.visible");
 
             cy.waitUntil(() =>
-                cy.document().then(doc => doc.querySelector(".notification") == null)
+                cy.document().then((doc) => doc.querySelector(".notification") == null)
             );
 
             cy.contains("Input not provided").should("not.exist");
@@ -151,9 +151,9 @@ describe("misc", () => {
             cy.get("#landscape-overlay") // get the rotate device overlay element
                 .should("be.visible"); // assert that the overlay is visible
             cy.waitForGameReady();
-            
+
             cy.waitUntilDialogAppears();
-            
+
             cy.contains("How to play").should("not.be.visible");
         });
 
@@ -189,9 +189,9 @@ describe("misc", () => {
 
             cy.get("#landscape-overlay") // get the rotate device overlay element
                 .should("not.be.visible"); // assert that the overlay is not visible
-            
+
             cy.waitForGameReady();
-            
+
             cy.get("#embedim--snow").should("be.visible");
         });
 
@@ -225,7 +225,16 @@ describe("misc", () => {
             cy.waitForGameReady();
 
             cy.get("#embedim--snow").should("not.be.visible");
-        })
+        });
+    });
+
+    describe("noscript", () => {
+        // It's unreasonably difficult in Cypress atm to disable JS for one test, shouldn't have to manipulate the parent iframe just to do it.
+        // Putting the open issue URL here in case I want to revisit it: https://github.com/cypress-io/cypress/issues/1611
+        // Instead, I'll test for the inverse for now since this isn't critical.
+        it("should not display a message telling player to enable JS if it's enabled", () => {
+            cy.contains("Please enable JavaScript to play this game.").should("not.be.visible");
+        });
     });
 
     describe("cache-less tests", () => {

--- a/cypress/e2e/game/settings.cy.js
+++ b/cypress/e2e/game/settings.cy.js
@@ -252,4 +252,98 @@ describe("settings", () => {
             );
         });
     });
+
+    it("should be able to toggle hard mode if game is over", () => {
+        cy.keyboardItem("w").click();
+        cy.keyboardItem("r").click();
+        cy.keyboardItem("a").click();
+        cy.keyboardItem("t").click();
+        cy.keyboardItem("h").click();
+
+        cy.keyboardItem("enter").click();
+
+        cy.keyboardItem("d").click();
+        cy.keyboardItem("u").click();
+        cy.keyboardItem("c").click();
+        cy.keyboardItem("t").click();
+        cy.keyboardItem("s").click();
+
+        cy.keyboardItem("enter").click();
+
+        cy.get(".dialog > .close").click();
+
+        cy.get(".settings-link").click();
+
+        cy.get(".settings-item.hard-mode").should("contain.text", "OFF");
+        cy.window().then((win) => {
+            expect(win.localStorage.getItem("preferences")).to.be.null;
+        });
+
+        cy.get(".settings-item.hard-mode").click();
+
+        cy.get(".settings-item.hard-mode").should("contain.text", "ON");
+        cy.window().then((win) => {
+            expect(win.localStorage.getItem("preferences")).to.be.eql(
+                JSON.stringify({
+                    ["hard-mode"]: "enabled",
+                })
+            );
+        });
+    });
+
+    it("should be able to toggle easy mode if game is over", () => {
+        cy.visit("/", {
+            onBeforeLoad: () => {
+                window.localStorage.setItem("played_before", true);
+                window.localStorage.setItem(
+                    "preferences",
+                    JSON.stringify({
+                        ["hard-mode"]: "enabled",
+                    })
+                );
+            },
+        });
+
+        cy.keyboardItem("w").click();
+        cy.keyboardItem("r").click();
+        cy.keyboardItem("a").click();
+        cy.keyboardItem("t").click();
+        cy.keyboardItem("h").click();
+
+        cy.keyboardItem("enter").click();
+
+        cy.keyboardItem("d").click();
+        cy.keyboardItem("u").click();
+        cy.keyboardItem("c").click();
+        cy.keyboardItem("t").click();
+        cy.keyboardItem("s").click();
+
+        cy.keyboardItem("enter").click();
+
+        cy.get(".dialog > .close").click();
+
+        cy.get(".settings-link").click();
+
+        cy.get(".settings-item.hard-mode").should("contain.text", "ON");
+        cy.window().then((win) => {
+            expect(win.localStorage.getItem("preferences")).to.be.eql(
+                JSON.stringify({
+                    ["hard-mode"]: "enabled",
+                })
+            );
+        });
+
+        cy.get(".settings-item.hard-mode").click();
+
+        cy.contains("Hard mode can only be enabled at the start of a round").should("not.exist");
+
+        cy.get(".settings-item.hard-mode").should("contain.text", "OFF");
+        cy.window().then((win) => {
+            expect(win.localStorage.getItem("preferences")).to.be.eql(
+                JSON.stringify({
+                    ["hard-mode"]: "disabled",
+                })
+            );
+        });
+    });
 });

--- a/cypress/e2e/game/share.cy.js
+++ b/cypress/e2e/game/share.cy.js
@@ -183,14 +183,16 @@ describe("sharing results", () => {
     });
 
     it("should add asterisk if hard mode is enabled", () => {
-        window.localStorage.setItem(
-            "preferences",
-            JSON.stringify({
-                ["hard-mode"]: "enabled",
-            })
-        );
-
-        cy.reload();
+        cy.visit("/", {
+            onBeforeLoad: () => {
+                window.localStorage.setItem(
+                    "preferences",
+                    JSON.stringify({
+                        ["hard-mode"]: "enabled",
+                    })
+                );
+            },
+        });
 
         const PREV_COPIED_TEXT =
             "This text should not be in clipboard when the copy button is clicked";
@@ -203,6 +205,81 @@ describe("sharing results", () => {
         });
 
         performAction("leafy");
+
+        cy.window().then(async (win) => {
+            const copiedText = await win.navigator.clipboard.readText();
+            expect(copiedText).to.eq(`Wordle Clone 1 2/6*
+⬛🟨⬛⬛🟨
+🟩🟩🟩🟩🟩`);
+        });
+    });
+
+    it("should not add asterisk if hard mode is enabled after ending the game on easy", () => {
+        const PREV_COPIED_TEXT =
+            "This text should not be in clipboard when the copy button is clicked";
+
+        cy.window().then(async (win) => {
+            win.focus();
+            await win.navigator.clipboard.writeText(PREV_COPIED_TEXT);
+            const copiedText = await win.navigator.clipboard.readText();
+            expect(copiedText).to.eq(PREV_COPIED_TEXT);
+        });
+
+        performAction("leafy");
+
+        cy.visit("/", {
+            onBeforeLoad: () => {
+                window.localStorage.setItem(
+                    "preferences",
+                    JSON.stringify({
+                        ["hard-mode"]: "enabled",
+                    })
+                );
+            },
+        });
+
+        cy.window().then(async (win) => {
+            const copiedText = await win.navigator.clipboard.readText();
+            expect(copiedText).to.eq(`Wordle Clone 1 2/6
+⬛🟨⬛⬛🟨
+🟩🟩🟩🟩🟩`);
+        });
+    });
+
+    it("should keep asterisk if hard mode is disabled after ending the game on hard", () => {
+        cy.visit("/", {
+            onBeforeLoad: () => {
+                window.localStorage.setItem(
+                    "preferences",
+                    JSON.stringify({
+                        ["hard-mode"]: "enabled",
+                    })
+                );
+            },
+        });
+
+        const PREV_COPIED_TEXT =
+            "This text should not be in clipboard when the copy button is clicked";
+
+        cy.window().then(async (win) => {
+            win.focus();
+            await win.navigator.clipboard.writeText(PREV_COPIED_TEXT);
+            const copiedText = await win.navigator.clipboard.readText();
+            expect(copiedText).to.eq(PREV_COPIED_TEXT);
+        });
+
+        performAction("leafy");
+
+        cy.visit("/", {
+            onBeforeLoad: () => {
+                window.localStorage.setItem(
+                    "preferences",
+                    JSON.stringify({
+                        ["hard-mode"]: "disabled",
+                    })
+                );
+            },
+        });
 
         cy.window().then(async (win) => {
             const copiedText = await win.navigator.clipboard.readText();

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -114,10 +114,10 @@ Cypress.Commands.add("shouldBeInViewport", { prevSubject: true }, (subject) => {
 
 Cypress.Commands.add("waitUntilDialogAppears", () => {
     cy.waitUntil(() =>
-        cy.window().then(win => {
-            cy.get(".dialog").then(dialog =>
-                parseInt(win.getComputedStyle(dialog[0]).top) <= win.innerHeight / 2
-            )
+        cy.window().then((win) => {
+            cy.get(".dialog").then(
+                (dialog) => parseInt(win.getComputedStyle(dialog[0]).top) <= win.innerHeight / 2
+            );
         })
     );
 });

--- a/src/game.js
+++ b/src/game.js
@@ -97,6 +97,7 @@ const newState = () => {
         lives: STARTING_LIVES,
         attempts: [],
         ended: false,
+        wonHardMode: false,
     };
 };
 

--- a/src/game.js
+++ b/src/game.js
@@ -291,7 +291,7 @@ const initGame = async (_eventHandler) => {
     }
 };
 
-const submitWord = (gameState, currentInput, previousAttempt) => {
+const submitWord = (gameState, currentInput, previousAttempt, hardMode) => {
     if (gameState.lives <= 0) {
         return eventHandler("error", USER_RAN_OUT_OF_LIVES_ERROR_ID);
     }
@@ -307,6 +307,9 @@ const submitWord = (gameState, currentInput, previousAttempt) => {
     if (result.results.every((entry) => entry.correct)) {
         eventHandler("win");
         gameState.ended = true;
+        // If the player won on hard mode, then the game should still indicate
+        // that they won on hard mode, even if they switch difficulty after, and vice versa.
+        gameState.wonHardMode = hardMode;
     } else {
         gameState.lives--;
         if (gameState.lives === 0) {
@@ -316,7 +319,13 @@ const submitWord = (gameState, currentInput, previousAttempt) => {
             eventHandler("lose_life");
         }
     }
-    saveGame(gameState.attempts, gameState.lives, gameState.ended, currentDay);
+    saveGame(
+        gameState.attempts,
+        gameState.lives,
+        gameState.ended,
+        currentDay,
+        gameState.wonHardMode
+    );
 };
 
 if (typeof process !== "undefined") {

--- a/src/index.js
+++ b/src/index.js
@@ -98,7 +98,7 @@ document.addEventListener("DOMContentLoaded", async () => {
                 e.preventDefault();
                 const shareText = generateShareText(day, gameState.attempts, STARTING_LIVES, {
                     highContrastMode,
-                    hardMode,
+                    hardMode: gameState.wonHardMode,
                 });
                 copyShareText(shareText);
             });
@@ -199,7 +199,8 @@ document.addEventListener("DOMContentLoaded", async () => {
                 currentInput,
                 hardMode && gameState.attempts.length > 0
                     ? gameState.attempts[gameState.attempts.length - 1]
-                    : null
+                    : null,
+                hardMode
             );
         } else if (key.length === 1 && key >= "a" && key <= "z" && currentLetterIndex < 5) {
             wordleRenderer.renderInput(key);
@@ -320,7 +321,7 @@ document.addEventListener("DOMContentLoaded", async () => {
                 );
                 toggle.innerText = enabled ? "ON" : "OFF";
             } else if (elem.classList.contains(HARD_MODE_PREFERENCE_NAME)) {
-                if (!hardMode && gameState.attempts.length > 0) {
+                if (!hardMode && gameState.attempts.length > 0 && !gameState.ended) {
                     return renderNotification(
                         "Hard mode can only be enabled at the start of a round"
                     );

--- a/src/storage/browser.js
+++ b/src/storage/browser.js
@@ -5,15 +5,17 @@ if (typeof process !== "undefined") {
     DAY_KEY = storage.DAY_KEY;
     ENDED_KEY = storage.ENDED_KEY;
     PLAYED_BEFORE_KEY = storage.PLAYED_BEFORE_KEY;
+    WON_HARD_MODE_KEY = storage.WON_HARD_MODE_KEY;
     PREFERENCES_KEY = storage.PREFERENCES_KEY;
     STARTING_LIVES = require("../consts").STARTING_LIVES;
 }
 
-const saveGame = (attempts, lives, ended, day) => {
+const saveGame = (attempts, lives, ended, day, wonHardMode) => {
     window.localStorage.setItem(ATTEMPTS_KEY, JSON.stringify(attempts));
     window.localStorage.setItem(LIVES_KEY, lives);
     window.localStorage.setItem(ENDED_KEY, ended);
     window.localStorage.setItem(DAY_KEY, day);
+    window.localStorage.setItem(WON_HARD_MODE_KEY, wonHardMode);
 };
 
 const savePreferences = (preferences) => {
@@ -21,16 +23,18 @@ const savePreferences = (preferences) => {
 };
 
 const loadGame = () => {
-    const attempts = JSON.parse(window.localStorage.getItem(ATTEMPTS_KEY) || "[]");
+    const attempts = JSON.parse(window.localStorage.getItem(ATTEMPTS_KEY)) || [];
     let lives = parseInt(window.localStorage.getItem(LIVES_KEY));
     if (lives == null || isNaN(lives)) {
         lives = STARTING_LIVES;
     }
-    const ended = JSON.parse(window.localStorage.getItem(ENDED_KEY) || "false");
+    const ended = JSON.parse(window.localStorage.getItem(ENDED_KEY)) || false;
+    const wonHardMode = JSON.parse(window.localStorage.getItem(WON_HARD_MODE_KEY)) || false;
     return {
         attempts,
         lives,
         ended,
+        wonHardMode,
     };
 };
 
@@ -52,6 +56,7 @@ const clearGame = () => {
     window.localStorage.removeItem(ATTEMPTS_KEY);
     window.localStorage.removeItem(LIVES_KEY);
     window.localStorage.removeItem(DAY_KEY);
+    window.localStorage.removeItem(WON_HARD_MODE_KEY);
 };
 
 const clearPreferences = () => {

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -4,6 +4,7 @@ const DAY_KEY = "day";
 const ENDED_KEY = "ended";
 const PLAYED_BEFORE_KEY = "played_before";
 const PREFERENCES_KEY = "preferences";
+const WON_HARD_MODE_KEY = "won_hard_mode";
 
 if (typeof process !== "undefined") {
     module.exports = {
@@ -13,5 +14,6 @@ if (typeof process !== "undefined") {
         ENDED_KEY,
         PLAYED_BEFORE_KEY,
         PREFERENCES_KEY,
+        WON_HARD_MODE_KEY,
     };
 }


### PR DESCRIPTION
Other Changes:
- Also retain whether the user won on hard mode or not in the share text, even if they switch difficulty after completing the round
- Remove separate playedbefore.json state file, the played before state is now rolled into state.json, so that all game state is in one place
- Add a test for noscript behaviour in browser version