### PR TITLE
Add theme selection pane with card-based preview

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -7,6 +7,12 @@
             "options": {
                 "tabWidth": 2
             }
+        },
+        {
+            "files": "*.css",
+            "options": {
+                "printWidth": 120
+            }
         }
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add theme selection pane with previews
 - Browser interface and/or status bar colour will dim alongside the rest of the game's elements when a dialog is open
 
 ### Fixed

--- a/cypress/e2e/game/settings.cy.js
+++ b/cypress/e2e/game/settings.cy.js
@@ -51,7 +51,7 @@ describe("settings", () => {
         cy.get(".keyboard").should("not.be.visible");
         cy.contains("Settings").should("be.visible");
 
-        cy.get(".close").click();
+        cy.get(".settings .close").click();
 
         cy.get(".keyboard").should("be.visible");
         cy.contains("Settings").should("not.be.visible");
@@ -117,12 +117,15 @@ describe("settings", () => {
         cy.contains("embed.im").should("not.be.visible");
 
         cy.get(".setting.theme-switch").click();
-        cy.get(".setting.theme-switch").click();
+        cy.get(".theme-card.snow").click();
+        cy.get(".themes .back").click();
 
         cy.get("body").should("have.class", "snow");
         cy.contains("embed.im").should("be.visible");
 
         cy.get(".setting.theme-switch").click();
+        cy.get(".theme-card.dark").click();
+        cy.get(".themes .back").click();
 
         cy.get("body").should("not.have.class", "snow");
         cy.contains("embed.im").should("not.be.visible");

--- a/cypress/e2e/game/theme.cy.js
+++ b/cypress/e2e/game/theme.cy.js
@@ -23,21 +23,22 @@ describe("theme", () => {
 
     it("should be able to select from any of the available themes", () => {
         cy.get(".settings-link").click();
+        cy.get(".setting.theme-switch").click();
 
         cy.get("body").should("have.class", "");
         cy.get("body").should("have.css", "background-color", "rgb(0, 0, 0)");
 
-        cy.get(".setting.theme-switch").click();
+        cy.get(".theme-card.light").click();
 
         cy.get("body").should("have.class", "light");
         cy.get("body").should("have.css", "background-color", "rgb(255, 255, 255)");
 
-        cy.get(".setting.theme-switch").click();
+        cy.get(".theme-card.snow").click();
 
         cy.get("body").should("have.class", "snow");
         cy.get("body").should("have.css", "background-color", "rgb(2, 0, 36)");
 
-        cy.get(".setting.theme-switch").click();
+        cy.get(".theme-card.dark").click();
 
         cy.get("body").should("have.class", "");
         cy.get("body").should("have.css", "background-color", "rgb(0, 0, 0)");
@@ -131,6 +132,7 @@ describe("theme", () => {
     it("should set the correct meta theme-color for light theme", () => {
         cy.get(".settings-link").click();
         cy.get(".setting.theme-switch").click();
+        cy.get(".theme-card.light").click();
 
         cy.get("body").should("have.class", "light");
         cy.get("meta[name='theme-color']").should("have.attr", "content", "#ffffff");
@@ -139,7 +141,7 @@ describe("theme", () => {
     it("should set the correct meta theme-color for snow theme", () => {
         cy.get(".settings-link").click();
         cy.get(".setting.theme-switch").click();
-        cy.get(".setting.theme-switch").click();
+        cy.get(".theme-card.snow").click();
 
         cy.get("body").should("have.class", "snow");
         cy.get("meta[name='theme-color']").should("have.attr", "content", "#020024");
@@ -158,7 +160,8 @@ describe("theme", () => {
     it("should apply dimmed theme-color when a dialog is opened in light theme", () => {
         cy.get(".settings-link").click();
         cy.get(".setting.theme-switch").click();
-        cy.get(".settings .close").click();
+        cy.get(".theme-card.light").click();
+        cy.get(".themes .close").click();
 
         cy.get("body").should("have.class", "light");
         cy.get("meta[name='theme-color']").should("have.attr", "content", "#ffffff");
@@ -172,8 +175,8 @@ describe("theme", () => {
     it("should apply dimmed theme-color when a dialog is opened in snow theme", () => {
         cy.get(".settings-link").click();
         cy.get(".setting.theme-switch").click();
-        cy.get(".setting.theme-switch").click();
-        cy.get(".settings .close").click();
+        cy.get(".theme-card.snow").click();
+        cy.get(".themes .close").click();
 
         cy.get("body").should("have.class", "snow");
         cy.get("meta[name='theme-color']").should("have.attr", "content", "#020024");
@@ -187,7 +190,8 @@ describe("theme", () => {
     it("should restore normal theme-color when dialog is closed", () => {
         cy.get(".settings-link").click();
         cy.get(".setting.theme-switch").click();
-        cy.get(".settings .close").click();
+        cy.get(".theme-card.light").click();
+        cy.get(".themes .close").click();
 
         cy.get("body").should("have.class", "light");
         cy.get("meta[name='theme-color']").should("have.attr", "content", "#ffffff");
@@ -202,7 +206,8 @@ describe("theme", () => {
     it("should restore normal theme-color when dialog is closed via overlay click", () => {
         cy.get(".settings-link").click();
         cy.get(".setting.theme-switch").click();
-        cy.get(".settings .close").click();
+        cy.get(".theme-card.light").click();
+        cy.get(".themes .close").click();
 
         cy.get("body").should("have.class", "light");
         cy.get("meta[name='theme-color']").should("have.attr", "content", "#ffffff");
@@ -217,7 +222,8 @@ describe("theme", () => {
     it("should restore normal theme-color when dialog is closed via escape key", () => {
         cy.get(".settings-link").click();
         cy.get(".setting.theme-switch").click();
-        cy.get(".settings .close").click();
+        cy.get(".theme-card.light").click();
+        cy.get(".themes .close").click();
 
         cy.get("body").should("have.class", "light");
         cy.get("meta[name='theme-color']").should("have.attr", "content", "#ffffff");

--- a/cypress/e2e/game/themes-pane.cy.js
+++ b/cypress/e2e/game/themes-pane.cy.js
@@ -1,0 +1,82 @@
+/// <reference types="cypress" />
+
+const DAY_MS = 86400000;
+// March 23 2022 - initial release date
+const FIRST_DAY_MS = 1647993600000;
+
+describe("themes pane", () => {
+    beforeEach(() => {
+        cy.clock(FIRST_DAY_MS + DAY_MS * 1 + (DAY_MS * 1) / 2, ["Date"]);
+        cy.intercept("/words.txt", {
+            fixture: "words.txt",
+        });
+        cy.clearBrowserCache();
+        cy.visit("/", {
+            onBeforeLoad: () => {
+                window.localStorage.setItem("wc_played_before", true);
+            },
+        });
+        cy.waitForGameReady();
+        cy.get(".settings-link").click();
+        cy.get(".setting.theme-switch").click();
+    });
+
+    it("should appear in place of the settings pane when the theme setting is clicked", () => {
+        cy.contains("Settings").should("not.be.visible");
+        cy.contains("Themes").should("be.visible");
+        cy.get(".keyboard").should("not.be.visible");
+    });
+
+    it("should show a card for each selectable theme", () => {
+        cy.get(".theme-card.dark").should("be.visible");
+        cy.get(".theme-card.light").should("be.visible");
+        cy.get(".theme-card.snow").should("be.visible");
+    });
+
+    it("should mark the currently active theme card", () => {
+        cy.get(".theme-card.dark").should("have.class", "active");
+        cy.get(".theme-card.light").should("not.have.class", "active");
+        cy.get(".theme-card.snow").should("not.have.class", "active");
+    });
+
+    it("should switch theme and update active card when a card is clicked", () => {
+        cy.get(".theme-card.light").click();
+        cy.get("body").should("have.class", "light");
+        cy.get(".theme-card.light").should("have.class", "active");
+        cy.get(".theme-card.dark").should("not.have.class", "active");
+    });
+
+    it("should update the settings theme toggle label when a card is selected", () => {
+        cy.get(".theme-card.light").click();
+        cy.get(".themes .back").click();
+        cy.get(".setting.theme-switch .toggle").should("have.text", "light");
+    });
+
+    it("should return to settings pane when the back button is clicked", () => {
+        cy.contains("Themes").should("be.visible");
+        cy.get(".themes .back").click();
+        cy.contains("Settings").should("be.visible");
+        cy.contains("Themes").should("not.be.visible");
+        cy.get(".keyboard").should("not.be.visible");
+    });
+
+    it("should return to the game when the close button is clicked", () => {
+        cy.contains("Themes").should("be.visible");
+        cy.get(".themes .close").click();
+        cy.get(".keyboard").should("be.visible");
+        cy.contains("Themes").should("not.be.visible");
+    });
+
+    it("should have a scrollable theme cards container", () => {
+        cy.get(".theme-cards")
+            .should("have.css", "overflow-y")
+            .and("match", /auto|scroll/);
+    });
+
+    it("should have theme cards container constrained to pane height to allow scrolling", () => {
+        cy.get(".theme-cards").then(($el) => {
+            const el = $el[0];
+            expect(el.scrollHeight).to.be.at.least(el.clientHeight);
+        });
+    });
+});

--- a/cypress/e2e/game/themes-pane.cy.js
+++ b/cypress/e2e/game/themes-pane.cy.js
@@ -68,7 +68,7 @@ describe("themes pane", () => {
     });
 
     it("should scroll to reveal all theme cards on a small phone screen", () => {
-        cy.viewport(375, 480);
+        cy.viewport(400, 480);
 
         cy.get(".theme-cards")
             .should("have.css", "overflow-y")

--- a/cypress/e2e/game/themes-pane.cy.js
+++ b/cypress/e2e/game/themes-pane.cy.js
@@ -67,16 +67,33 @@ describe("themes pane", () => {
         cy.contains("Themes").should("not.be.visible");
     });
 
-    it("should have a scrollable theme cards container", () => {
+    it("should scroll to reveal all theme cards on a small phone screen", () => {
+        cy.viewport(375, 480);
+
         cy.get(".theme-cards")
             .should("have.css", "overflow-y")
             .and("match", /auto|scroll/);
-    });
 
-    it("should have theme cards container constrained to pane height to allow scrolling", () => {
-        cy.get(".theme-cards").then(($el) => {
-            const el = $el[0];
-            expect(el.scrollHeight).to.be.at.least(el.clientHeight);
+        cy.get(".theme-cards").then(($container) => {
+            const container = $container[0];
+            expect(container.scrollHeight).to.be.greaterThan(container.clientHeight);
+
+            const containerRect = container.getBoundingClientRect();
+            const snowCard = container.querySelector(".theme-card.snow");
+            const snowRect = snowCard.getBoundingClientRect();
+            // Snow starts in view but its bottom is clipped by the container
+            expect(snowRect.top).to.be.lessThan(containerRect.bottom);
+            expect(snowRect.bottom).to.be.greaterThan(containerRect.bottom);
+        });
+
+        cy.get(".theme-cards").scrollTo("bottom");
+
+        cy.get(".theme-cards").then(($container) => {
+            const containerRect = $container[0].getBoundingClientRect();
+            const snowRect = $container[0]
+                .querySelector(".theme-card.snow")
+                .getBoundingClientRect();
+            expect(snowRect.bottom).to.be.at.most(containerRect.bottom);
         });
     });
 });

--- a/index.css
+++ b/index.css
@@ -744,6 +744,11 @@ body a > .commit-hash {
     position: absolute;
     top: 0;
     left: 0;
+    z-index: 1;
+    width: 2.5rem;
+    height: 2.5rem;
+    background-color: transparent;
+    color: black;
 }
 
 .themes > button.close {
@@ -791,6 +796,10 @@ body.high-contrast .theme-card {
     font-weight: bold;
     font-size: 0.85rem;
     text-transform: capitalize;
+}
+
+.theme-card.snow .theme-card-name {
+    color: white;
 }
 
 .theme-card-board {

--- a/index.css
+++ b/index.css
@@ -771,6 +771,7 @@ body a > .commit-hash {
     overflow-y: auto;
     flex: 1;
     min-height: 0;
+    outline: none;
 }
 
 .theme-card {
@@ -790,13 +791,13 @@ body a > .commit-hash {
 
 .theme-card.snow {
     overflow: hidden;
+    background-clip: padding-box;
     --incorrect-color: var(--gray-2);
     --box-border-color: var(--gray-3);
     background:
-        radial-gradient(circle, rgba(255,255,255,0.85) 1.5px, transparent 1.5px) 4px 6px / 18px 16px,
-        radial-gradient(circle, rgba(255,255,255,0.6) 1px, transparent 1px) 14px 2px / 28px 22px,
-        radial-gradient(circle, rgba(255,255,255,0.75) 1.2px, transparent 1.2px) 9px 18px / 22px 30px,
-        radial-gradient(circle, rgba(255,255,255,0.5) 1px, transparent 1px) 22px 14px / 35px 18px,
+        radial-gradient(circle, rgba(255,255,255,0.85) 1.5px, transparent 1.5px) 6px 14px / 24px 22px,
+        radial-gradient(circle, rgba(255,255,255,0.6) 1px, transparent 1px) 21px 3px / 38px 28px,
+        radial-gradient(circle, rgba(255,255,255,0.7) 1.2px, transparent 1.2px) 12px 24px / 22px 40px,
         linear-gradient(180deg, rgba(2, 0, 36, 1) 40%, rgba(9, 9, 121, 1) 100%);
 }
 

--- a/index.css
+++ b/index.css
@@ -789,6 +789,7 @@ body a > .commit-hash {
     background: var(--background-color);
     user-select: none;
     outline: none;
+    font: inherit;
 }
 
 .theme-card.snow {

--- a/index.css
+++ b/index.css
@@ -40,6 +40,8 @@
 
     --notification-background-color: var(--gray-7);
     --notification-text-color: var(--black);
+
+    --active-card-border-color: var(--white);
 }
 
 .light {
@@ -61,6 +63,8 @@
 
     --notification-background-color: var(--black);
     --notification-text-color: var(--white);
+
+    --active-card-border-color: var(--black);
 }
 
 .snow {
@@ -709,4 +713,136 @@ body a > .commit-hash {
 
 .knob.enabled > .knob-inside {
     left: 29px;
+}
+
+/* Dark theme scoping class (used on theme cards to enforce dark theme variables) */
+
+.dark {
+    --standard-color: var(--gray-5);
+    --standard-block-color: var(--black);
+    --correct-color: var(--green);
+    --within-color: var(--yellow);
+    --incorrect-color: var(--gray-2);
+    --box-border-color: var(--gray-3);
+    --box-border-color-highlighted: var(--gray-5);
+    --background-color: var(--black);
+    --fallback-background-color: var(--black);
+    --text-color: var(--white);
+    --letter-text-color: var(--white);
+    --letter-selected-text-color: var(--white);
+    --letter-selected-inverted-text-color: var(--white);
+    --active-card-border-color: var(--white);
+}
+
+/* Themes Pane */
+
+.themes {
+    position: relative;
+}
+
+.themes > button.close {
+    position: absolute;
+    top: 0;
+    right: 0;
+}
+
+.theme-cards {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    padding: 0 1rem;
+    width: 100%;
+    box-sizing: border-box;
+    overflow-y: auto;
+}
+
+.theme-card {
+    border: 2px solid transparent;
+    border-radius: 8px;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0.5rem;
+    gap: 0.4rem;
+    background: var(--fallback-background-color);
+    background: var(--background-color);
+    user-select: none;
+}
+
+.theme-card.active {
+    border-color: var(--active-card-border-color);
+}
+
+.theme-card-name {
+    color: var(--text-color);
+    font-weight: bold;
+    font-size: 0.85rem;
+    text-transform: capitalize;
+}
+
+.theme-card-board {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.theme-card-row {
+    display: flex;
+    gap: 2px;
+}
+
+.theme-card-box {
+    width: 16px;
+    height: 16px;
+    border: 1px solid var(--box-border-color);
+    background-color: var(--standard-block-color);
+}
+
+.theme-card-box.correct {
+    background-color: var(--correct-color);
+    border-color: transparent;
+}
+
+.theme-card-box.within {
+    background-color: var(--within-color);
+    border-color: transparent;
+}
+
+.theme-card-box.incorrect {
+    background-color: var(--incorrect-color);
+    border-color: transparent;
+}
+
+.theme-card-keyboard {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    width: 100%;
+}
+
+.theme-card-keyboard-row {
+    display: flex;
+    gap: 2px;
+    justify-content: center;
+}
+
+.theme-card-key {
+    height: 10px;
+    width: 8px;
+    border-radius: 1px;
+    background-color: var(--standard-color);
+}
+
+.theme-card-key.correct {
+    background-color: var(--correct-color);
+}
+
+.theme-card-key.within {
+    background-color: var(--within-color);
+}
+
+.theme-card-key.incorrect {
+    background-color: var(--incorrect-color);
 }

--- a/index.css
+++ b/index.css
@@ -804,6 +804,11 @@ body a > .commit-hash {
         linear-gradient(180deg, rgba(2, 0, 36, 1) 40%, rgba(9, 9, 121, 1) 100%);
 }
 
+.theme-card:focus-visible {
+    outline: 2px solid var(--active-card-border-color);
+    outline-offset: 2px;
+}
+
 .theme-card.active {
     border-color: var(--active-card-border-color);
 }

--- a/index.css
+++ b/index.css
@@ -740,6 +740,12 @@ body a > .commit-hash {
     position: relative;
 }
 
+.themes > button.back {
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
 .themes > button.close {
     position: absolute;
     top: 0;

--- a/index.css
+++ b/index.css
@@ -56,6 +56,7 @@
     --box-border-color-highlighted: var(--gray-5);
 
     --background-color: var(--white);
+    --fallback-background-color: var(--background-color);
     --dialog-background-color: var(--gray-6);
 
     --text-color: var(--black);
@@ -791,8 +792,7 @@ body a > .commit-hash {
     align-items: center;
     padding: 0.5rem;
     gap: 0.4rem;
-    background: var(--fallback-background-color);
-    background: var(--background-color);
+    background: var(--background-color, var(--fallback-background-color));
     background-clip: padding-box;
     user-select: none;
     outline: none;
@@ -834,7 +834,7 @@ body.high-contrast .theme-card {
 }
 
 .theme-card.snow .theme-card-name {
-    color: white;
+    color: var(--white);
 }
 
 .theme-card-board {

--- a/index.css
+++ b/index.css
@@ -763,7 +763,8 @@ body a > .commit-hash {
 
 .theme-cards {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(2, minmax(0, 160px));
+    justify-content: center;
     gap: 1rem;
     padding: 0 1rem;
     width: 100%;

--- a/index.css
+++ b/index.css
@@ -748,7 +748,7 @@ body a > .commit-hash {
     width: 2.5rem;
     height: 2.5rem;
     background-color: transparent;
-    color: black;
+    color: var(--text-color);
 }
 
 .themes > button.close {

--- a/index.css
+++ b/index.css
@@ -757,6 +757,10 @@ body a > .commit-hash {
     right: 0;
 }
 
+.themes > .space {
+    flex: 0 0 0.5rem;
+}
+
 .theme-cards {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -765,6 +769,8 @@ body a > .commit-hash {
     width: 100%;
     box-sizing: border-box;
     overflow-y: auto;
+    flex: 1;
+    min-height: 0;
 }
 
 .theme-card {
@@ -779,6 +785,19 @@ body a > .commit-hash {
     background: var(--fallback-background-color);
     background: var(--background-color);
     user-select: none;
+    outline: none;
+}
+
+.theme-card.snow {
+    overflow: hidden;
+    --incorrect-color: var(--gray-2);
+    --box-border-color: var(--gray-3);
+    background:
+        radial-gradient(circle, rgba(255,255,255,0.85) 1.5px, transparent 1.5px) 4px 6px / 18px 16px,
+        radial-gradient(circle, rgba(255,255,255,0.6) 1px, transparent 1px) 14px 2px / 28px 22px,
+        radial-gradient(circle, rgba(255,255,255,0.75) 1.2px, transparent 1.2px) 9px 18px / 22px 30px,
+        radial-gradient(circle, rgba(255,255,255,0.5) 1px, transparent 1px) 22px 14px / 35px 18px,
+        linear-gradient(180deg, rgba(2, 0, 36, 1) 40%, rgba(9, 9, 121, 1) 100%);
 }
 
 .theme-card.active {

--- a/index.css
+++ b/index.css
@@ -42,6 +42,7 @@
     --notification-text-color: var(--black);
 
     --active-card-border-color: var(--white);
+    --focused-card-border-color: var(--within-color);
 }
 
 .light {
@@ -80,6 +81,8 @@
     --correct-color: var(--orange);
     --within-color: var(--blue);
     --letter-selected-inverted-text-color: var(--black);
+
+    --focused-card-border-color: var(--within-color);
 }
 
 /* Main Content */
@@ -805,7 +808,7 @@ body a > .commit-hash {
 }
 
 .theme-card:focus-visible {
-    outline: 2px solid var(--active-card-border-color);
+    outline: 2px solid var(--focused-card-border-color);
     outline-offset: 2px;
 }
 

--- a/index.css
+++ b/index.css
@@ -763,7 +763,7 @@ body a > .commit-hash {
 
 .theme-cards {
     display: grid;
-    grid-template-columns: repeat(auto-fit, 160px);
+    grid-template-columns: repeat(auto-fit, 155px);
     justify-content: center;
     align-items: start;
     gap: 1rem;

--- a/index.css
+++ b/index.css
@@ -768,15 +768,16 @@ body a > .commit-hash {
     background: var(--fallback-background-color);
     background: var(--background-color);
     user-select: none;
-
-    /* Prevent high contrast mode from affecting card previews */
-    --correct-color: var(--green);
-    --within-color: var(--yellow);
-    --letter-selected-inverted-text-color: var(--white);
 }
 
 .theme-card.active {
     border-color: var(--active-card-border-color);
+}
+
+body.high-contrast .theme-card {
+    --correct-color: var(--orange);
+    --within-color: var(--blue);
+    --letter-selected-inverted-text-color: var(--black);
 }
 
 .theme-card-name {

--- a/index.css
+++ b/index.css
@@ -769,6 +769,7 @@ body a > .commit-hash {
 .theme-cards {
     display: grid;
     grid-template-columns: repeat(auto-fit, 155px);
+    grid-auto-rows: 220px;
     justify-content: center;
     align-items: start;
     gap: 1rem;
@@ -792,6 +793,7 @@ body a > .commit-hash {
     gap: 0.4rem;
     background: var(--fallback-background-color);
     background: var(--background-color);
+    background-clip: padding-box;
     user-select: none;
     outline: none;
     font: inherit;
@@ -799,7 +801,6 @@ body a > .commit-hash {
 
 .theme-card.snow {
     overflow: hidden;
-    background-clip: padding-box;
     --incorrect-color: var(--gray-2);
     --box-border-color: var(--gray-3);
     background:
@@ -807,6 +808,7 @@ body a > .commit-hash {
         radial-gradient(circle, rgba(255, 255, 255, 0.6) 1px, transparent 1px) 21px 3px / 38px 28px,
         radial-gradient(circle, rgba(255, 255, 255, 0.7) 1.2px, transparent 1.2px) 12px 24px / 22px 40px,
         linear-gradient(180deg, rgba(2, 0, 36, 1) 40%, rgba(9, 9, 121, 1) 100%);
+    background-clip: padding-box;
 }
 
 .theme-card:focus-visible {

--- a/index.css
+++ b/index.css
@@ -768,6 +768,11 @@ body a > .commit-hash {
     background: var(--fallback-background-color);
     background: var(--background-color);
     user-select: none;
+
+    /* Prevent high contrast mode from affecting card previews */
+    --correct-color: var(--green);
+    --within-color: var(--yellow);
+    --letter-selected-inverted-text-color: var(--white);
 }
 
 .theme-card.active {

--- a/index.css
+++ b/index.css
@@ -332,7 +332,9 @@ button.button > * {
 
     opacity: 1;
 
-    transition: top 0.5s, opacity 0.5s;
+    transition:
+        top 0.5s,
+        opacity 0.5s;
 }
 
 @media (max-width: 320px) {
@@ -801,9 +803,9 @@ body a > .commit-hash {
     --incorrect-color: var(--gray-2);
     --box-border-color: var(--gray-3);
     background:
-        radial-gradient(circle, rgba(255,255,255,0.85) 1.5px, transparent 1.5px) 6px 14px / 24px 22px,
-        radial-gradient(circle, rgba(255,255,255,0.6) 1px, transparent 1px) 21px 3px / 38px 28px,
-        radial-gradient(circle, rgba(255,255,255,0.7) 1.2px, transparent 1.2px) 12px 24px / 22px 40px,
+        radial-gradient(circle, rgba(255, 255, 255, 0.85) 1.5px, transparent 1.5px) 6px 14px / 24px 22px,
+        radial-gradient(circle, rgba(255, 255, 255, 0.6) 1px, transparent 1px) 21px 3px / 38px 28px,
+        radial-gradient(circle, rgba(255, 255, 255, 0.7) 1.2px, transparent 1.2px) 12px 24px / 22px 40px,
         linear-gradient(180deg, rgba(2, 0, 36, 1) 40%, rgba(9, 9, 121, 1) 100%);
 }
 

--- a/index.css
+++ b/index.css
@@ -770,7 +770,7 @@ body a > .commit-hash {
 .theme-cards {
     display: grid;
     grid-template-columns: repeat(auto-fit, 155px);
-    grid-auto-rows: 220px;
+    grid-auto-rows: 210px;
     justify-content: center;
     align-items: start;
     gap: 1rem;

--- a/index.css
+++ b/index.css
@@ -763,8 +763,9 @@ body a > .commit-hash {
 
 .theme-cards {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 160px));
+    grid-template-columns: repeat(auto-fit, 160px);
     justify-content: center;
+    align-items: start;
     gap: 1rem;
     padding: 0 1rem;
     width: 100%;

--- a/index.html
+++ b/index.html
@@ -62,15 +62,15 @@
             </div>
             <div class="themes pane" style="display:none">
                 <h1>Themes</h1>
-                <button class="back"><i data-feather="arrow-left"></i></button>
-                <button class="close"><i data-feather="x"></i></button>
+                <button class="back" aria-label="Back"><i data-feather="arrow-left"></i></button>
+                <button class="close" aria-label="Close themes"><i data-feather="x"></i></button>
                 <div class="space"></div>
                 <div class="theme-cards"></div>
                 <div class="space"></div>
             </div>
             <div class="settings pane" style="display:none">
                 <h1>Settings</h1>
-                <button class="close"><i data-feather="x"></i></button>
+                <button class="close" aria-label="Close settings"><i data-feather="x"></i></button>
                 <div class="space"></div>
                 <div class="settings-item-group">
                     <div class="settings-item setting theme-switch">

--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
             </div>
             <div class="themes pane" style="display:none">
                 <h1>Themes</h1>
+                <button class="back"><i data-feather="arrow-left"></i></button>
                 <button class="close"><i data-feather="x"></i></button>
                 <div class="space"></div>
                 <div class="theme-cards"></div>
@@ -282,6 +283,7 @@
                 document.querySelector("[data-feather='settings']").innerText = "⚙";
                 document.querySelector(".settings [data-feather='x']").innerText = "X";
                 document.querySelector(".themes [data-feather='x']").innerText = "X";
+                document.querySelector(".themes [data-feather='arrow-left']").innerText = "<";
             }
             
             if (typeof Sentry !== "undefined") {

--- a/index.html
+++ b/index.html
@@ -60,6 +60,13 @@
                     </div>
                 </noscript>
             </div>
+            <div class="themes pane" style="display:none">
+                <h1>Themes</h1>
+                <button class="close"><i data-feather="x"></i></button>
+                <div class="space"></div>
+                <div class="theme-cards"></div>
+                <div class="space"></div>
+            </div>
             <div class="settings pane" style="display:none">
                 <h1>Settings</h1>
                 <button class="close"><i data-feather="x"></i></button>
@@ -274,6 +281,7 @@
                 document.querySelector("[data-feather='help-circle']").innerText = "?";
                 document.querySelector("[data-feather='settings']").innerText = "⚙";
                 document.querySelector(".settings [data-feather='x']").innerText = "X";
+                document.querySelector(".themes [data-feather='x']").innerText = "X";
             }
             
             if (typeof Sentry !== "undefined") {

--- a/src/index.js
+++ b/src/index.js
@@ -245,6 +245,9 @@ document.addEventListener("DOMContentLoaded", async () => {
         if (dialog && key === "escape") {
             return closeDialog(dialog, overlayBackElem);
         }
+        if (gamePane.style.display === "none") {
+            return;
+        }
         if (dialog || gameState.ended || ctrlKey || metaKey) {
             return;
         }

--- a/src/index.js
+++ b/src/index.js
@@ -312,16 +312,29 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     const gamePane = document.querySelector(".game");
     const settingsPane = document.querySelector(".settings");
+    const themesPane = document.querySelector(".themes");
     const settingsLink = document.querySelector(".settings-link");
+
+    const showThemesPane = () => {
+        settingsPane.style.display = "none";
+        themesPane.style.display = "flex";
+        updateThemeCardActiveState();
+    };
+
+    const hideThemesPane = () => {
+        themesPane.style.display = "none";
+        settingsPane.style.display = "flex";
+    };
 
     const toggleSettings = () => {
         settingsLink.blur();
-        if (settingsPane.style.display === "none") {
-            gamePane.style.display = "none";
-            settingsPane.style.display = "flex";
-        } else {
+        if (settingsPane.style.display !== "none" || themesPane.style.display !== "none") {
             gamePane.style.display = "flex";
             settingsPane.style.display = "none";
+            themesPane.style.display = "none";
+        } else {
+            gamePane.style.display = "none";
+            settingsPane.style.display = "flex";
         }
     };
 
@@ -334,6 +347,12 @@ document.addEventListener("DOMContentLoaded", async () => {
     settingsClose.addEventListener("click", (e) => {
         e.preventDefault();
         toggleSettings();
+    });
+
+    const themesClose = themesPane.querySelector(".close");
+    themesClose.addEventListener("click", (e) => {
+        e.preventDefault();
+        hideThemesPane();
     });
 
     const overlayBackElem = document.querySelector(".overlay-back");
@@ -358,18 +377,105 @@ document.addEventListener("DOMContentLoaded", async () => {
         selectedKeyboard = keyboard;
     };
 
+    const PREVIEW_BOARD_ROWS = [
+        ["correct", "within", "incorrect", "correct", "incorrect"],
+        ["within", "correct", "incorrect", "correct", "incorrect"],
+        ["correct", "correct", "correct", "correct", "correct"],
+        ["", "", "", "", ""],
+        ["", "", "", "", ""],
+        ["", "", "", "", ""],
+    ];
+
+    const PREVIEW_KEYBOARD_ROWS = [
+        ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"],
+        ["a", "s", "d", "f", "g", "h", "j", "k", "l"],
+        ["z", "x", "c", "v", "b", "n", "m"],
+    ];
+
+    const PREVIEW_LETTER_STATES = {
+        c: "correct", r: "within", n: "correct", s: "correct",
+        t: "correct", o: "correct", w: "correct", g: "incorrect",
+    };
+
+    const updateThemeCardActiveState = () => {
+        document.querySelectorAll(".theme-card").forEach((card) => {
+            if (card.dataset.theme === themeManager.getSelectedTheme()) {
+                card.classList.add("active");
+            } else {
+                card.classList.remove("active");
+            }
+        });
+    };
+
+    const buildThemeCards = () => {
+        const themeCardsElem = document.querySelector(".theme-cards");
+        selectableThemes.forEach((theme) => {
+            const card = document.createElement("div");
+            card.className = `theme-card ${theme}`;
+            card.dataset.theme = theme;
+            card.setAttribute("role", "button");
+            card.setAttribute("tabindex", "0");
+
+            const nameElem = document.createElement("span");
+            nameElem.className = "theme-card-name";
+            nameElem.innerText = theme;
+            card.appendChild(nameElem);
+
+            const boardElem = document.createElement("div");
+            boardElem.className = "theme-card-board";
+            PREVIEW_BOARD_ROWS.forEach((row) => {
+                const rowElem = document.createElement("div");
+                rowElem.className = "theme-card-row";
+                row.forEach((state) => {
+                    const box = document.createElement("div");
+                    box.className = `theme-card-box${state ? ` ${state}` : ""}`;
+                    rowElem.appendChild(box);
+                });
+                boardElem.appendChild(rowElem);
+            });
+            card.appendChild(boardElem);
+
+            const keyboardElem = document.createElement("div");
+            keyboardElem.className = "theme-card-keyboard";
+            PREVIEW_KEYBOARD_ROWS.forEach((row) => {
+                const rowElem = document.createElement("div");
+                rowElem.className = "theme-card-keyboard-row";
+                row.forEach((letter) => {
+                    const key = document.createElement("div");
+                    const state = PREVIEW_LETTER_STATES[letter] || "";
+                    key.className = `theme-card-key${state ? ` ${state}` : ""}`;
+                    rowElem.appendChild(key);
+                });
+                keyboardElem.appendChild(rowElem);
+            });
+            card.appendChild(keyboardElem);
+
+            const applyTheme = () => {
+                themeManager.switchTheme(theme);
+                savePreferenceValue(THEME_PREFERENCE_NAME, theme);
+                document.querySelector(`.setting.${THEME_PREFERENCE_NAME}-switch .toggle`).innerText = theme;
+                updateThemeCardActiveState();
+            };
+
+            card.addEventListener("click", applyTheme);
+            card.addEventListener("keydown", (e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    applyTheme();
+                }
+            });
+
+            themeCardsElem.appendChild(card);
+        });
+    };
+
     const settings = document.querySelectorAll(".setting");
     settings.forEach((setting) => {
         setting.addEventListener("click", (e) => {
             const elem = e.target;
             let enabled = false;
             if (elem.classList.contains(`${THEME_PREFERENCE_NAME}-switch`)) {
-                const toggle = setting.querySelector(".toggle");
-                const themeIndex = selectableThemes.indexOf(themeManager.getSelectedTheme());
-                const nextTheme = selectableThemes[(themeIndex + 1) % selectableThemes.length];
-                themeManager.switchTheme(nextTheme);
-                savePreferenceValue(THEME_PREFERENCE_NAME, nextTheme);
-                toggle.innerText = nextTheme;
+                showThemesPane();
             } else if (elem.classList.contains(HIGH_CONTRAST_PREFERENCE_NAME)) {
                 const knob = setting.querySelector(".knob");
                 enabled = highContrastMode = !highContrastMode;
@@ -421,6 +527,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     initPreferences();
     themeManager.switchTheme(getPreferenceValue(THEME_PREFERENCE_NAME));
     switchKeyboard(getPreferenceValue(KEYBOARD_PREFERENCE_NAME));
+    buildThemeCards();
     const themeSetting = document.querySelector(`.setting.${THEME_PREFERENCE_NAME}-switch`);
     themeSetting.querySelector(".toggle").innerText = themeManager.getSelectedTheme();
     const keyboardSetting = document.querySelector(`.setting.${KEYBOARD_PREFERENCE_NAME}-switch`);

--- a/src/index.js
+++ b/src/index.js
@@ -410,22 +410,18 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     const updateThemeCardActiveState = () => {
         document.querySelectorAll(".theme-card").forEach((card) => {
-            if (card.dataset.theme === themeManager.getSelectedTheme()) {
-                card.classList.add("active");
-            } else {
-                card.classList.remove("active");
-            }
+            const isSelected = card.dataset.theme === themeManager.getSelectedTheme();
+            card.classList.toggle("active", isSelected);
+            card.setAttribute("aria-label", isSelected ? `${card.dataset.theme} (selected)` : card.dataset.theme);
         });
     };
 
     const buildThemeCards = () => {
         const themeCardsElem = document.querySelector(".theme-cards");
         selectableThemes.forEach((theme) => {
-            const card = document.createElement("div");
+            const card = document.createElement("button");
             card.className = `theme-card ${theme}`;
             card.dataset.theme = theme;
-            card.setAttribute("role", "button");
-            card.setAttribute("tabindex", "0");
 
             const nameElem = document.createElement("span");
             nameElem.className = "theme-card-name";
@@ -469,12 +465,6 @@ document.addEventListener("DOMContentLoaded", async () => {
             };
 
             card.addEventListener("click", applyTheme);
-            card.addEventListener("keydown", (e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    applyTheme();
-                }
-            });
 
             themeCardsElem.appendChild(card);
         });

--- a/src/index.js
+++ b/src/index.js
@@ -326,6 +326,11 @@ document.addEventListener("DOMContentLoaded", async () => {
         settingsPane.style.display = "flex";
     };
 
+    const closeThemesPane = () => {
+        themesPane.style.display = "none";
+        gamePane.style.display = "flex";
+    };
+
     const toggleSettings = () => {
         settingsLink.blur();
         if (settingsPane.style.display !== "none" || themesPane.style.display !== "none") {
@@ -349,10 +354,16 @@ document.addEventListener("DOMContentLoaded", async () => {
         toggleSettings();
     });
 
+    const themesBack = themesPane.querySelector(".back");
+    themesBack.addEventListener("click", (e) => {
+        e.preventDefault();
+        hideThemesPane();
+    });
+
     const themesClose = themesPane.querySelector(".close");
     themesClose.addEventListener("click", (e) => {
         e.preventDefault();
-        hideThemesPane();
+        closeThemesPane();
     });
 
     const overlayBackElem = document.querySelector(".overlay-back");


### PR DESCRIPTION
Replaces the click-to-cycle theme toggle in Settings with a dedicated
Themes pane showing each theme as a card with a mini game board and
keyboard preview. Clicking a card immediately applies and persists the
theme. The active theme is highlighted with a border.

https://claude.ai/code/session_01VZTorvD5TumdL6NiaAaQKV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Themes pane with interactive theme cards, live previews, back/close controls, keyboard preview, and persisted selection.

* **Style**
  * Expanded theme variables for light/dark/snow/high-contrast, focused/active borders, per-theme preview styling, and refined transitions.

* **Bug Fixes / UX**
  * Accessible fallbacks for pane controls and added aria-label on settings close.

* **Tests**
  * Updated and added end-to-end tests covering themes pane, selection flow, and responsive behavior.

* **Chores**
  * Formatting config extended to include CSS formatting rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->