### PR TITLE
Add Cypress test and fix for win dialog null crash (render.js fadeIn)

### DIFF
--- a/cypress/e2e/game/dialog.cy.js
+++ b/cypress/e2e/game/dialog.cy.js
@@ -4,6 +4,56 @@ const DAY_MS = 86400000;
 // March 23 2022 - initial release date
 const FIRST_DAY_MS = 1647993600000;
 
+describe("win dialog fadeIn animation", () => {
+    beforeEach(() => {
+        // Freeze ALL timers (including setTimeout) so we can control when the fadeIn timer fires.
+        // This lets us close the dialog before the 10ms timer runs - which is the race condition
+        // that causes "can't access property 'style', dialog is null" (render.js:221).
+        cy.clock(FIRST_DAY_MS + DAY_MS * 1 + (DAY_MS * 1) / 2);
+        cy.intercept("/words.txt", {
+            fixture: "words.txt",
+        });
+        cy.clearBrowserCache();
+        cy.visit("/", {
+            onBeforeLoad: (win) => {
+                win.localStorage.setItem("wc_played_before", "true");
+            },
+        });
+        cy.waitForGameReady();
+        // Win the game (word for this day is "leafy")
+        cy.keyboardItem("l").click();
+        cy.keyboardItem("e").click();
+        cy.keyboardItem("a").click();
+        cy.keyboardItem("f").click();
+        cy.keyboardItem("y").click();
+        cy.keyboardItem("enter").click();
+    });
+
+    it("should display win dialog after player wins", () => {
+        // Tick to fire the frozen fadeIn timer - dialog transitions from opacity:0 to visible
+        cy.tick(10);
+        cy.contains("You win!").should("be.visible");
+    });
+
+    it("should not throw when the dialog is removed before the fadeIn timer fires", () => {
+        // The win dialog is shown with opacity:0 (timer is frozen, so it stays invisible).
+        // Clicking the overlay while the dialog is invisible is what triggers the bug in prod -
+        // the player sees nothing and clicks through, closing the dialog. When the frozen 10ms
+        // timer eventually fires, document.querySelector(".dialog") returns null and throws.
+        cy.get(".dialog").should("exist");
+
+        // Close the dialog before the timer fires (simulates overlay click on the invisible dialog)
+        cy.get(".overlay-back").click();
+
+        cy.get(".dialog").should("not.exist");
+
+        // Fire the frozen fadeIn timer - this is where the crash occurs with the buggy code:
+        // "Uncaught TypeError: can't access property 'style', dialog is null" (render.js:221)
+        // Cypress automatically fails the test if an uncaught exception is thrown.
+        cy.tick(10);
+    });
+});
+
 describe("dialogs", () => {
     beforeEach(() => {
         // only mock the "Date" object, otherwise events that use setTimeout like dialog messages won't work

--- a/src/render.js
+++ b/src/render.js
@@ -217,7 +217,6 @@ const renderDialog = (content, options) => {
             dialog.style.opacity = "0";
             dialog.style.top = "100%";
             setTimeout(() => {
-                const dialog = document.querySelector(".dialog");
                 dialog.style.opacity = "";
                 dialog.style.top = "";
             }, 10);


### PR DESCRIPTION
The 10ms fadeIn setTimeout in renderDialog re-queried the DOM with
document.querySelector(".dialog") instead of closing over the dialog
variable already in scope. If the dialog was removed before that timer
fired (e.g. the overlay became visible while the dialog was still at
opacity:0, and a click landed on it), the query returned null and threw
"can't access property 'style', dialog is null".

Fix: drop the re-declaration inside the setTimeout so it closes over
the existing dialog reference. A detached element reference is safe to
write styles to; a null one is not.

The new Cypress describe freezes all timers with cy.clock() so the
fadeIn callback can be triggered at an exact moment via cy.tick(10),
making the race condition reliably reproducible.

https://claude.ai/code/session_01DYsKXcjAhF95UkPuT3v4Wk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved uncaught exceptions in win dialog handling during animation edge cases.

* **Tests**
  * Added comprehensive test coverage for win dialog fade-in animation behavior and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->